### PR TITLE
Replaced all backslash in basedir of fixtures with normal slash

### DIFF
--- a/mwa-jpa/src/main/java/com/github/jknack/mwa/jpa/JpaFixtures.java
+++ b/mwa-jpa/src/main/java/com/github/jknack/mwa/jpa/JpaFixtures.java
@@ -149,7 +149,7 @@ public final class JpaFixtures {
   @SuppressWarnings({"unchecked", "rawtypes" })
   public static <T> Iterable<T> load(final ApplicationContext applicationContext,
       final Map<String, ClassMetadata> metadata, final String baseDir) throws IOException {
-    String pattern = new File(baseDir, "**/*.yml").toString();
+    String pattern = new File(baseDir, "**/*.yml").toString().replace('\\', '/');
 
     logger.debug("Searching for: {}", pattern);
 


### PR DESCRIPTION
Change made since the given implementation in org.springframework.core.io.support.PathMatchingResourcePatternResolver.determineRootDir(String) that requires a slash.
