### PR TITLE
Move context initialization into a reusable location

### DIFF
--- a/mwa-jpa/src/main/java/com/github/jknack/mwa/jpa/IntegrationTestContextInitializer.java
+++ b/mwa-jpa/src/main/java/com/github/jknack/mwa/jpa/IntegrationTestContextInitializer.java
@@ -1,0 +1,39 @@
+package com.github.jknack.mwa.jpa;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+import com.github.jknack.mwa.ApplicationContextConfigurer;
+
+/**
+ * Application context initializer that adds the properties
+ * required by MWA's ApplicationContextConfigurer and related
+ * classes. Useful mostly for integration tests and proofs of
+ * concepts.
+ * @author Paul Hicks
+ */
+public class IntegrationTestContextInitializer implements
+    ApplicationContextInitializer<GenericApplicationContext> {
+  @Override
+  public void initialize(final GenericApplicationContext applicationContext) {
+    MutablePropertySources propertySources = new MutablePropertySources();
+    // use mem db and publish a namespace
+    Map<String, Object> testProperties = new HashMap<String, Object>();
+    testProperties.put("db", "mem");
+    testProperties.put("application.ns", getClass().getPackage().getName());
+
+    applicationContext.registerBeanDefinition("conversionService",
+        new RootBeanDefinition(DefaultConversionService.class));
+
+    propertySources.addFirst(new MapPropertySource("integrationTest", testProperties));
+
+    ApplicationContextConfigurer.configure(applicationContext, propertySources);
+  }
+}

--- a/mwa-jpa/src/test/java/com/github/jknack/mwa/jpa/JpaFixturesIntegrationTest.java
+++ b/mwa-jpa/src/test/java/com/github/jknack/mwa/jpa/JpaFixturesIntegrationTest.java
@@ -3,50 +3,23 @@ package com.github.jknack.mwa.jpa;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.core.env.MutablePropertySources;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.github.jknack.mwa.ApplicationContextConfigurer;
-
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(loader = JpaFixturesIntegrationTest.class, classes = JpaModule.class)
+@ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = JpaModule.class, initializers = IntegrationTestContextInitializer.class)
 @Transactional
 @TransactionConfiguration(transactionManager = "transactionManager", defaultRollback = true)
-public class JpaFixturesIntegrationTest extends AnnotationConfigContextLoader {
-
-  @Override
-  protected void customizeContext(final GenericApplicationContext context) {
-    MutablePropertySources propertySources = new MutablePropertySources();
-    // use mem db and publish a namespace
-    Map<String, Object> testProperties = new HashMap<String, Object>();
-    testProperties.put("db", "mem");
-    testProperties.put("application.ns", getClass().getPackage().getName());
-
-    context.registerBeanDefinition("conversionService", new RootBeanDefinition(
-        DefaultConversionService.class));
-
-    propertySources.addFirst(new MapPropertySource("integrationTest", testProperties));
-
-    ApplicationContextConfigurer.configure(context, propertySources);
-  }
-
+public class JpaFixturesIntegrationTest {
   @Inject
   private EntityManager em;
 


### PR DESCRIPTION
Just moving some code from src/test into src/main,
because it's useful for integration tests in other projects.
I've also moved it to a context initializer class and changed
the original test class to use the new class in the appropriate way.